### PR TITLE
Creates the `sync_queue` table

### DIFF
--- a/supabase/migrations/20250111000000_create_sync_queue_table.sql
+++ b/supabase/migrations/20250111000000_create_sync_queue_table.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS sync_queue (
+  id SERIAL PRIMARY KEY,
+  tx_hash TEXT NOT NULL UNIQUE,
+  entity_type TEXT NOT NULL CHECK (entity_type IN ('player', 'fish', 'tank', 'decoration')),
+  entity_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'failed')),
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_queue_tx_hash ON sync_queue(tx_hash);
+
+CREATE INDEX IF NOT EXISTS idx_sync_queue_status ON sync_queue(status);
+
+CREATE INDEX IF NOT EXISTS idx_sync_queue_entity ON sync_queue(entity_type, entity_id);
+
+CREATE OR REPLACE FUNCTION update_sync_queue_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_sync_queue_updated_at
+  BEFORE UPDATE ON sync_queue
+  FOR EACH ROW
+  EXECUTE FUNCTION update_sync_queue_updated_at();


### PR DESCRIPTION
## 🔗 Related Issue
Closes #31

---

## 📝 Description
Creates the `sync_queue` table in Supabase to track pending on-chain transactions. This table enables synchronization between blockchain (Starknet/Dojo) and off-chain database (Supabase), preventing data inconsistencies when transactions are not yet confirmed.

---

## 🔄 Changes Made
- [x] Create `sync_queue` table with fields: id, tx_hash (unique), entity_type, entity_id, status, retry_count, created_at, updated_at
- [x] Add CHECK constraints for `entity_type` ('player', 'fish', 'tank', 'decoration') and `status` ('pending', 'confirmed', 'failed')
- [x] Create unique index on `tx_hash` for efficient lookups
- [x] Create index on `status` for filtering pending transactions
- [x] Create composite index on `(entity_type, entity_id)` for entity lookups
- [x] Implement trigger to auto-update `updated_at` on row modifications
- [x] Add `retry_count` field for handling failed transaction retries
- [x] Create SQL migration `20250111000000_create_sync_queue_table.sql`

---

## 📸 Screenshots (if applicable)
N/A - Database changes

---

## 🗒️ Additional Notes
- The table does not use foreign keys due to the polymorphic relationship with different entity types
- `entity_id` is TEXT to support different ID types (address for players, integer for fish/tanks/decorations)
- The `update_sync_queue_updated_at` trigger automatically updates the `updated_at` field on each modification
- This table will be used by a background worker process to confirm transactions and synchronize data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database infrastructure to support entity synchronization tracking with automatic timestamp management and data integrity constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->