### PR TITLE
Creates 4 public storage buckets in Supabase

### DIFF
--- a/docs/supabase-storage-setup.md
+++ b/docs/supabase-storage-setup.md
@@ -1,0 +1,41 @@
+# Supabase Storage Setup
+
+Configuración de buckets de almacenamiento para assets del juego.
+
+## Buckets
+
+Se crean 4 buckets públicos para lectura:
+
+- `fish` - Sprites de peces
+- `tanks` - Sprites de tanques
+- `decorations` - Sprites de decoraciones
+- `avatars` - Avatares de jugadores
+
+## Convenciones de nombres
+
+- Fish: `fish-{id}.png`
+- Tanks: `tank-{id}.png`
+- Decorations: `decoration-{id}.png`
+- Avatars: `avatar-{player_address}.png`
+
+## Acceso
+
+- **Lectura**: Público (accesible desde Unity client)
+- **Escritura**: Solo usuarios autenticados
+
+## URLs públicas
+
+```
+https://{supabase-url}/storage/v1/object/public/{bucket}/{filename}
+```
+
+Ejemplo:
+```
+https://momjlqhhapbaigjwociq.supabase.co/storage/v1/object/public/fish/fish-1.png
+```
+
+## Aplicar migración
+
+```bash
+npx supabase db push
+```

--- a/docs/supabase-storage-setup.md
+++ b/docs/supabase-storage-setup.md
@@ -1,40 +1,40 @@
 # Supabase Storage Setup
 
-Configuración de buckets de almacenamiento para assets del juego.
+Storage bucket configuration for game assets.
 
 ## Buckets
 
-Se crean 4 buckets públicos para lectura:
+4 public buckets are created for reading:
 
-- `fish` - Sprites de peces
-- `tanks` - Sprites de tanques
-- `decorations` - Sprites de decoraciones
-- `avatars` - Avatares de jugadores
+- `fish` - Fish sprites
+- `tanks` - Tank sprites
+- `decorations` - Decoration sprites
+- `avatars` - Player avatars
 
-## Convenciones de nombres
+## Naming Conventions
 
 - Fish: `fish-{id}.png`
 - Tanks: `tank-{id}.png`
 - Decorations: `decoration-{id}.png`
 - Avatars: `avatar-{player_address}.png`
 
-## Acceso
+## Access
 
-- **Lectura**: Público (accesible desde Unity client)
-- **Escritura**: Solo usuarios autenticados
+- **Read**: Public (accessible from Unity client)
+- **Write**: Authenticated users only
 
-## URLs públicas
+## Public URLs
 
 ```
 https://{supabase-url}/storage/v1/object/public/{bucket}/{filename}
 ```
 
-Ejemplo:
+Example:
 ```
 https://momjlqhhapbaigjwociq.supabase.co/storage/v1/object/public/fish/fish-1.png
 ```
 
-## Aplicar migración
+## Apply Migration
 
 ```bash
 npx supabase db push

--- a/supabase/migrations/20250113000000_create_storage_buckets.sql
+++ b/supabase/migrations/20250113000000_create_storage_buckets.sql
@@ -1,0 +1,120 @@
+-- Storage buckets for game assets
+-- Public read access for Unity client, authenticated write access only
+
+-- Create fish bucket
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('fish', 'fish', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Create tanks bucket
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('tanks', 'tanks', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Create decorations bucket
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('decorations', 'decorations', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Create avatars bucket
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Public read policies for all buckets
+CREATE POLICY "Public read access for fish"
+ON storage.objects
+FOR SELECT
+TO public
+USING (bucket_id = 'fish');
+
+CREATE POLICY "Public read access for tanks"
+ON storage.objects
+FOR SELECT
+TO public
+USING (bucket_id = 'tanks');
+
+CREATE POLICY "Public read access for decorations"
+ON storage.objects
+FOR SELECT
+TO public
+USING (bucket_id = 'decorations');
+
+CREATE POLICY "Public read access for avatars"
+ON storage.objects
+FOR SELECT
+TO public
+USING (bucket_id = 'avatars');
+
+-- Authenticated write policies for all buckets
+CREATE POLICY "Authenticated upload for fish"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'fish');
+
+CREATE POLICY "Authenticated upload for tanks"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'tanks');
+
+CREATE POLICY "Authenticated upload for decorations"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'decorations');
+
+CREATE POLICY "Authenticated upload for avatars"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'avatars');
+
+CREATE POLICY "Authenticated update for fish"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (bucket_id = 'fish');
+
+CREATE POLICY "Authenticated update for tanks"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (bucket_id = 'tanks');
+
+CREATE POLICY "Authenticated update for decorations"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (bucket_id = 'decorations');
+
+CREATE POLICY "Authenticated update for avatars"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (bucket_id = 'avatars');
+
+CREATE POLICY "Authenticated delete for fish"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (bucket_id = 'fish');
+
+CREATE POLICY "Authenticated delete for tanks"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (bucket_id = 'tanks');
+
+CREATE POLICY "Authenticated delete for decorations"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (bucket_id = 'decorations');
+
+CREATE POLICY "Authenticated delete for avatars"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (bucket_id = 'avatars');


### PR DESCRIPTION
## 🔗 Related Issue
Closes #32

---

## 📝 Description
Creates 4 public storage buckets in Supabase Storage for game assets (fish, tanks, decorations, avatars) with public read policies and authenticated-only write access. Includes documentation on structure and naming conventions.

---

## 🔄 Changes Made
- [x] Create SQL migration for 4 storage buckets (`fish`, `tanks`, `decorations`, `avatars`)
- [x] Configure RLS policies for public read (SELECT) and authenticated write (INSERT/UPDATE/DELETE)
- [x] Create documentation in `docs/supabase-storage-setup.md` with structure, conventions, and examples

---

## 📸 Screenshots (if applicable)
N/A

---

## 🗒️ Additional Notes
- Buckets are public for reading (accessible from Unity client)
- Write access is restricted to authenticated users only
- Migration is applied with `npx supabase db push`
- Naming conventions documented: `fish-{id}.png`, `tank-{id}.png`, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Supabase Storage setup guide covering bucket configuration, naming conventions, access control rules, public object URL format, and migration instructions.

* **Chores**
  * Provisioned cloud storage for game assets with public read access and authenticated user write/update/delete controls across asset buckets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->