### PR TITLE
Implements the starter pack minting functionality for new players during registration

### DIFF
--- a/src/core/types/dojo-types.ts
+++ b/src/core/types/dojo-types.ts
@@ -46,3 +46,21 @@ export interface FishFamilyTree {
   ancestors: FishFamilyMember[];
   generation_count: number;
 }
+
+/**
+ * Result of minting a tank on-chain.
+ * Contains the transaction hash and the generated tank ID.
+ */
+export interface MintTankResult {
+  tx_hash: string;
+  tank_id: number;
+}
+
+/**
+ * Result of minting a fish on-chain.
+ * Contains the transaction hash and the generated fish ID.
+ */
+export interface MintFishResult {
+  tx_hash: string;
+  fish_id: number;
+}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -22,6 +22,8 @@ export type {
   TankOnChain,
   FishOnChain,
   DecorationOnChain,
+  MintTankResult,
+  MintFishResult,
 } from './dojo-types';
 
 export { DecorationKind } from './dojo-types';

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -2,13 +2,36 @@
  * @fileoverview Player Service
  * 
  * Handles business logic for player operations including registration,
- * retrieval, and synchronization between Supabase and on-chain data.
+ * retrieval, starter pack minting, and synchronization between Supabase and on-chain data.
  */
 
-import { ValidationError, OnChainError } from '@/core/errors';
+// ============================================================================
+// IMPORTS
+// ============================================================================
+
+import { ValidationError, OnChainError, ConflictError } from '@/core/errors';
 import { getSupabaseClient } from '@/core/utils/supabase-client';
-import { registerPlayer as registerPlayerOnChain } from '@/core/utils/dojo-client';
+import { logError } from '@/core/utils/logger';
+import {
+  registerPlayer as registerPlayerOnChain,
+  mintTank,
+  mintFish,
+  generateRandomDna,
+} from '@/core/utils/dojo-client';
 import type { Player, CreatePlayerDto } from '@/models/player.model';
+import type { MintTankResult, MintFishResult } from '@/core/types';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const STARTER_PACK_TANK_CAPACITY = 10;
+const STARTER_PACK_FISH_SPECIES = 'Starter Fish';
+const STARTER_PACK_FISH_IMAGE_URL = '/images/fish/starter-fish.png';
+
+// ============================================================================
+// PLAYER SERVICE
+// ============================================================================
 
 /**
  * Service for managing player data and operations.
@@ -19,6 +42,10 @@ import type { Player, CreatePlayerDto } from '@/models/player.model';
  * - Synchronization between off-chain and on-chain data
  */
 export class PlayerService {
+  // ============================================================================
+  // PLAYER REGISTRATION
+  // ============================================================================
+
   /**
    * Registers a new player or returns existing player.
    * 
@@ -82,6 +109,21 @@ export class PlayerService {
       .single();
 
     if (insertError) {
+      // Handle race condition: if player was created by another request between our check and insert
+      if (insertError.code === '23505') { // PostgreSQL unique violation
+        // Fetch the existing player that was just created
+        const { data: existingPlayerAfterRace, error: fetchError } = await supabase
+          .from('players')
+          .select('*')
+          .eq('address', address)
+          .single();
+        
+        if (fetchError || !existingPlayerAfterRace) {
+          throw new Error(`Failed to fetch player after race condition: ${fetchError?.message}`);
+        }
+        
+        return this.mapSupabaseToPlayer(existingPlayerAfterRace);
+      }
       throw new Error(`Failed to create player in Supabase: ${insertError.message}`);
     }
 
@@ -101,17 +143,323 @@ export class PlayerService {
       );
     }
 
+    // Mint starter pack for new player (1 tank + 2 fish)
+    try {
+      await this.mintStarterPack(address);
+      // Re-fetch player to get updated fish_count
+      const { data: updatedPlayer } = await supabase
+        .from('players')
+        .select('*')
+        .eq('address', address)
+        .single();
+      
+      if (updatedPlayer) {
+        return this.mapSupabaseToPlayer(updatedPlayer);
+      }
+    } catch (error) {
+      // If starter pack minting fails, we still return the player
+      // but log the error for debugging
+      logError('Failed to mint starter pack', error);
+      // Player was created successfully, just without starter pack
+    }
+
     return this.mapSupabaseToPlayer(createdPlayer);
   }
 
+  // ============================================================================
+  // STARTER PACK MINTING
+  // ============================================================================
+
+  /**
+   * Mints the starter pack for a new player.
+   * 
+   * The starter pack includes:
+   * - 1 tank (capacity: 10)
+   * - 2 fish (species: "Starter Fish", random DNA)
+   * 
+   * Flow:
+   * 1. Validate player exists and has no starter pack yet
+   * 2. Mint all assets on-chain (tank + 2 fish)
+   * 3. Save all assets to Supabase with rollback on failure
+   * 4. Update player's fish_count
+   * 
+   * @param address - Player's wallet address
+   * @returns Object with tank_id and fish_ids
+   * @throws {ValidationError} If address is invalid
+   * @throws {ConflictError} If player already has starter pack
+   * @throws {OnChainError} If on-chain minting fails
+   */
+  async mintStarterPack(address: string): Promise<{
+    tank_id: number;
+    fish_ids: number[];
+  }> {
+    // PHASE 1: Validation
+    if (!address || address.trim().length === 0) {
+      throw new ValidationError('Address is required');
+    }
+
+    const supabase = getSupabaseClient();
+    const trimmedAddress = address.trim();
+
+    // Check if player exists
+    const { data: player, error: playerError } = await supabase
+      .from('players')
+      .select('address, fish_count')
+      .eq('address', trimmedAddress)
+      .single();
+
+    if (playerError || !player) {
+      throw new ValidationError('Player not found. Register first before minting starter pack.');
+    }
+
+    // Check if player already has starter pack (has fish or tanks)
+    // Use a more robust check that prevents race conditions
+    const { data: existingTanks, error: tanksError } = await supabase
+      .from('tanks')
+      .select('id')
+      .eq('owner', trimmedAddress)
+      .limit(1);
+
+    if (tanksError && tanksError.code !== 'PGRST116') {
+      // PGRST116 is "not found" - expected when no tanks exist
+      logError('Error checking for existing tanks', { error: tanksError });
+      throw new Error(`Failed to check for existing tanks: ${tanksError.message}`);
+    }
+
+    if (existingTanks && existingTanks.length > 0) {
+      throw new ConflictError('Player already has a starter pack (tank exists)');
+    }
+
+    // Also check fish count in database (more reliable than player.fish_count which might be stale)
+    const { count: fishCount, error: fishCountError } = await supabase
+      .from('fish')
+      .select('id', { count: 'exact', head: true })
+      .eq('owner', trimmedAddress);
+
+    if (fishCountError) {
+      logError('Error checking for existing fish', { error: fishCountError });
+      throw new Error(`Failed to check for existing fish: ${fishCountError.message}`);
+    }
+
+    if ((fishCount ?? 0) > 0) {
+      throw new ConflictError(`Player already has a starter pack (${fishCount} fish exist)`);
+    }
+
+    if (player.fish_count > 0) {
+      throw new ConflictError('Player already has a starter pack (fish_count > 0)');
+    }
+
+    // PHASE 2: Mint all assets on-chain first
+    // If any mint fails, we stop immediately without saving anything to Supabase
+    let tankResult: MintTankResult;
+    let fish1Result: MintFishResult;
+    let fish2Result: MintFishResult;
+
+    try {
+      // Mint tank on-chain
+      tankResult = await mintTank(trimmedAddress, STARTER_PACK_TANK_CAPACITY);
+    } catch (error) {
+      throw new OnChainError(
+        `Failed to mint tank on-chain: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+
+    try {
+      // Mint fish #1 on-chain
+      fish1Result = await mintFish(
+        trimmedAddress,
+        STARTER_PACK_FISH_SPECIES,
+        generateRandomDna()
+      );
+    } catch (error) {
+      throw new OnChainError(
+        `Failed to mint fish #1 on-chain: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        tankResult.tx_hash
+      );
+    }
+
+    try {
+      // Mint fish #2 on-chain
+      fish2Result = await mintFish(
+        trimmedAddress,
+        STARTER_PACK_FISH_SPECIES,
+        generateRandomDna()
+      );
+    } catch (error) {
+      throw new OnChainError(
+        `Failed to mint fish #2 on-chain: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        fish1Result.tx_hash
+      );
+    }
+
+    // PHASE 3: Save all assets to Supabase with rollback on failure
+    // Track what we've saved so we can rollback if needed
+    let tankSaved = false;
+    let fish1Saved = false;
+    let fish2Saved = false;
+
+    try {
+      // Save tank to Supabase
+      const { data: tankData, error: tankInsertError } = await supabase
+        .from('tanks')
+        .insert({
+          id: tankResult.tank_id,
+          owner: trimmedAddress,
+          name: 'Starter Tank',
+        })
+        .select();
+
+      if (tankInsertError) {
+        // Handle race condition: if tank with same ID was inserted by another request
+        if (tankInsertError.code === '23505') { // PostgreSQL unique violation
+          // Verify if this is the same owner (should not happen, but check anyway)
+          const { data: existingTank } = await supabase
+            .from('tanks')
+            .select('owner')
+            .eq('id', tankResult.tank_id)
+            .single();
+          
+          if (existingTank && existingTank.owner === trimmedAddress) {
+            // Same owner, consider it success (idempotent operation)
+            tankSaved = true;
+          } else {
+            // Different owner or other issue - this should not happen
+            logError('Tank ID conflict with different owner', { error: tankInsertError, tank_id: tankResult.tank_id });
+            throw new Error(`Tank ID conflict: ${tankInsertError.message}`);
+          }
+        } else {
+          logError('Failed to save tank to Supabase', { error: tankInsertError, tank_id: tankResult.tank_id });
+          throw new Error(`Failed to save tank: ${tankInsertError.message}`);
+        }
+      } else if (!tankData || tankData.length === 0) {
+        logError('Tank insert returned no data', { tank_id: tankResult.tank_id });
+        throw new Error('Failed to save tank: No data returned from insert');
+      } else {
+        tankSaved = true;
+      }
+
+      // Save fish #1 to Supabase
+      const { data: fish1Data, error: fish1InsertError } = await supabase
+        .from('fish')
+        .insert({
+          id: fish1Result.fish_id,
+          owner: trimmedAddress,
+          species: STARTER_PACK_FISH_SPECIES,
+          image_url: STARTER_PACK_FISH_IMAGE_URL,
+        })
+        .select();
+
+      if (fish1InsertError) {
+        // Handle race condition: if fish with same ID was inserted by another request
+        if (fish1InsertError.code === '23505') { // PostgreSQL unique violation
+          const { data: existingFish } = await supabase
+            .from('fish')
+            .select('owner')
+            .eq('id', fish1Result.fish_id)
+            .single();
+          
+          if (existingFish && existingFish.owner === trimmedAddress) {
+            fish1Saved = true;
+          } else {
+            logError('Fish #1 ID conflict with different owner', { error: fish1InsertError, fish_id: fish1Result.fish_id });
+            throw new Error(`Fish #1 ID conflict: ${fish1InsertError.message}`);
+          }
+        } else {
+          logError('Failed to save fish #1 to Supabase', { error: fish1InsertError, fish_id: fish1Result.fish_id });
+          throw new Error(`Failed to save fish #1: ${fish1InsertError.message}`);
+        }
+      } else if (!fish1Data || fish1Data.length === 0) {
+        logError('Fish #1 insert returned no data', { fish_id: fish1Result.fish_id });
+        throw new Error('Failed to save fish #1: No data returned from insert');
+      } else {
+        fish1Saved = true;
+      }
+
+      // Save fish #2 to Supabase
+      const { data: fish2Data, error: fish2InsertError } = await supabase
+        .from('fish')
+        .insert({
+          id: fish2Result.fish_id,
+          owner: trimmedAddress,
+          species: STARTER_PACK_FISH_SPECIES,
+          image_url: STARTER_PACK_FISH_IMAGE_URL,
+        })
+        .select();
+
+      if (fish2InsertError) {
+        // Handle race condition: if fish with same ID was inserted by another request
+        if (fish2InsertError.code === '23505') { // PostgreSQL unique violation
+          const { data: existingFish } = await supabase
+            .from('fish')
+            .select('owner')
+            .eq('id', fish2Result.fish_id)
+            .single();
+          
+          if (existingFish && existingFish.owner === trimmedAddress) {
+            fish2Saved = true;
+          } else {
+            logError('Fish #2 ID conflict with different owner', { error: fish2InsertError, fish_id: fish2Result.fish_id });
+            throw new Error(`Fish #2 ID conflict: ${fish2InsertError.message}`);
+          }
+        } else {
+          logError('Failed to save fish #2 to Supabase', { error: fish2InsertError, fish_id: fish2Result.fish_id });
+          throw new Error(`Failed to save fish #2: ${fish2InsertError.message}`);
+        }
+      } else if (!fish2Data || fish2Data.length === 0) {
+        logError('Fish #2 insert returned no data', { fish_id: fish2Result.fish_id });
+        throw new Error('Failed to save fish #2: No data returned from insert');
+      } else {
+        fish2Saved = true;
+      }
+
+      // Update player's fish_count
+      const { data: updateData, error: updateError } = await supabase
+        .from('players')
+        .update({ fish_count: 2 })
+        .eq('address', trimmedAddress)
+        .select();
+
+      if (updateError) {
+        logError('Failed to update fish_count', { error: updateError, address: trimmedAddress });
+        throw new Error(`Failed to update fish_count: ${updateError.message}`);
+      }
+      
+      if (!updateData || updateData.length === 0) {
+        logError('Player update returned no data', { address: trimmedAddress });
+        throw new Error('Failed to update fish_count: No data returned from update');
+      }
+
+      // All successful!
+      return {
+        tank_id: tankResult.tank_id,
+        fish_ids: [fish1Result.fish_id, fish2Result.fish_id],
+      };
+    } catch (error) {
+      // Rollback: delete what we saved
+      await this.rollbackSupabaseInserts(
+        supabase,
+        tankSaved ? tankResult.tank_id : undefined,
+        [
+          ...(fish1Saved ? [fish1Result.fish_id] : []),
+          ...(fish2Saved ? [fish2Result.fish_id] : []),
+        ]
+      );
+
+      throw new Error(
+        `Starter pack minting failed during Supabase save: ${error instanceof Error ? error.message : 'Unknown error'}. ` +
+        `On-chain mints were successful (tank_tx: ${tankResult.tx_hash}, fish1_tx: ${fish1Result.tx_hash}, fish2_tx: ${fish2Result.tx_hash}). ` +
+        `Rollback attempted.`
+      );
+    }
+  }
+
+  // ============================================================================
+  // HELPER METHODS
+  // ============================================================================
+
   /**
    * Maps Supabase player data to Player type.
-   * 
-   * Converts database timestamps to Date objects and ensures
-   * all required fields are present.
-   * 
-   * @param supabasePlayer - Raw player data from Supabase
-   * @returns Player object with proper types
+   * Converts database timestamps to Date objects and ensures all required fields are present.
    */
   private mapSupabaseToPlayer(supabasePlayer: any): Player {
     return {
@@ -125,5 +473,39 @@ export class PlayerService {
       created_at: new Date(supabasePlayer.created_at),
       updated_at: new Date(supabasePlayer.updated_at),
     };
+  }
+
+  /**
+   * Rollback helper: deletes saved records from Supabase.
+   * Used when a later operation fails and we need to clean up.
+   * 
+   * @param supabase - Supabase client instance
+   * @param tankId - Tank ID to delete (if saved)
+   * @param fishIds - Fish IDs to delete (if saved)
+   */
+  private async rollbackSupabaseInserts(
+    supabase: ReturnType<typeof getSupabaseClient>,
+    tankId?: number,
+    fishIds: number[] = []
+  ): Promise<void> {
+    // Delete fish first (foreign key order)
+    for (const fishId of fishIds) {
+      try {
+        await supabase.from('fish').delete().eq('id', fishId);
+      } catch (error) {
+        // Log but don't throw - best effort rollback
+        logError(`Rollback: Failed to delete fish ${fishId}`, error);
+      }
+    }
+
+    // Delete tank
+    if (tankId !== undefined) {
+      try {
+        await supabase.from('tanks').delete().eq('id', tankId);
+      } catch (error) {
+        // Log but don't throw - best effort rollback
+        logError(`Rollback: Failed to delete tank ${tankId}`, error);
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue

Closes #3

---

## 📝 Description

Implements the starter pack minting functionality for new players during registration. When a player registers for the first time, they automatically receive a starter pack containing:
- 1 tank (capacity: 10, named "Starter Tank")
- 2 fish (species: "Starter Fish" with random DNA)

The implementation includes robust ID generation that syncs with Supabase to maintain coherence between on-chain and off-chain IDs, handles race conditions to prevent duplicate assets, and implements rollback mechanisms to ensure data consistency when operations fail.

This ensures that new players start the game with initial assets, automatically minted both on-chain (via Dojo stubs) and stored off-chain (in Supabase).

---

## 🔄 Changes Made

- [x] Created `MintTankResult` and `MintFishResult` interfaces in `src/core/types/dojo-types.ts`
  - Contains `tx_hash` and generated IDs (`tank_id` or `fish_id`)
  - Re-exported in `src/core/types/index.ts`

- [x] Updated `src/core/utils/dojo-client.ts` with ID generation and synchronization
  - Implemented `syncCounters()` function that syncs with Supabase MAX(id)
  - Added global counters (`fishCounter`, `tankCounter`) with initialization tracking
  - Modified `mintTank()` and `mintFish()` to return `MintTankResult` and `MintFishResult`
  - Implemented `getNextFishId()` and `getNextTankId()` with DB synchronization
  - Added detection for manual database deletions to reset counters appropriately

- [x] Added `mintStarterPack()` method to `src/services/player.service.ts`
  - Validates player exists and has no existing starter pack
  - Mints tank and 2 fish on-chain first (Phase 1)
  - Saves all assets to Supabase with rollback on failure (Phase 2)
  - Updates player's `fish_count` to 2
  - Handles race conditions with PostgreSQL unique violation (23505) errors

- [x] Added `rollbackSupabaseInserts()` helper method
  - Deletes saved records if Supabase save fails after on-chain minting
  - Best-effort cleanup that logs errors but doesn't throw

- [x] Integrated `mintStarterPack()` into `registerPlayer()`
  - Automatically calls `mintStarterPack()` for newly created players
  - Re-fetches player after minting to return updated `fish_count`

---

## 🧪 Testing

### Tests Performed

All tests were performed manually using `curl` against the local server (`http://localhost:4000`).

#### ✅ Test 1: New Player Registration with Starter Pack

**Request:**

```json
POST /api/auth/login
{
  "address": "0x1234567890abcdef1234567890abcdef12345676"
}
```

**Result:** ✅ **PASSED**

- Status: `200 OK`
- Player created successfully in Supabase
- Tank minted on-chain with ID 1
- Two fish minted on-chain with IDs 1 and 2
- All assets saved to Supabase with matching IDs
- Player's `fish_count` updated to 2
- Response includes updated player data

**Response:**

```json
{
  "success": true,
  "data": {
    "address": "0x1234567890abcdef1234567890abcdef12345676",
    "total_xp": 0,
    "fish_count": 2,
    "tournaments_won": 0,
    "reputation": 0,
    "offspring_created": 0,
    "created_at": "2025-12-13T19:52:35.737Z",
    "updated_at": "2025-12-13T19:52:37.946Z"
  },
  "message": "Player logged in successfully"
}
```

---

#### ✅ Test 2: Second Player Registration

**Request:**

```json
POST /api/auth/login
{
  "address": "0x1234567890abcdef1234567890abcdef12345678"
}
```

**Result:** ✅ **PASSED**

- Status: `200 OK`
- Player created successfully
- Tank minted with ID 2 (consecutive)
- Fish minted with IDs 3 and 4 (consecutive)
- IDs maintain coherence across players
- All assets saved correctly

**Response:**

```json
{
  "success": true,
  "data": {
    "address": "0x1234567890abcdef1234567890abcdef12345678",
    "total_xp": 0,
    "fish_count": 2,
    "tournaments_won": 0,
    "reputation": 0,
    "offspring_created": 0,
    "created_at": "2025-12-13T19:52:44.263Z",
    "updated_at": "2025-12-13T19:52:46.170Z"
  },
  "message": "Player logged in successfully"
}
```

---

#### ✅ Test 3: Existing Player (No Duplicate Starter Pack)

**Request:**

```json
POST /api/auth/login
{
  "address": "0x1234567890abcdef1234567890abcdef12345676"
}
```

(Same address as Test 1)

**Result:** ✅ **PASSED**

- Status: `200 OK`
- Returns existing player without minting new starter pack
- No duplicate tanks or fish created
- `fish_count` remains at 2
- Idempotent behavior confirmed

**Response:**

```json
{
  "success": true,
  "data": {
    "address": "0x1234567890abcdef1234567890abcdef12345676",
    "total_xp": 0,
    "fish_count": 2,
    "tournaments_won": 0,
    "reputation": 0,
    "offspring_created": 0,
    "created_at": "2025-12-13T19:52:35.737Z",
    "updated_at": "2025-12-13T19:52:37.946Z"
  },
  "message": "Player logged in successfully"
}
```

---

#### ✅ Test 4: Manual Database Deletion and Re-registration

**Request:**

```json
POST /api/auth/login
{
  "address": "0x1234567890abcdef1234567890abcdef12345676"
}
```

(After manually deleting all records from `players`, `tanks`, and `fish` tables)

**Result:** ✅ **PASSED**

- Status: `200 OK`
- Counters reset correctly after manual deletion
- Tank minted with ID 1 (reset from previous higher IDs)
- Fish minted with IDs 1 and 2 (reset from previous higher IDs)
- Detects empty database and resets counters appropriately

**Response:**

```json
{
  "success": true,
  "data": {
    "address": "0x1234567890abcdef1234567890abcdef12345676",
    "total_xp": 0,
    "fish_count": 2,
    "tournaments_won": 0,
    "reputation": 0,
    "offspring_created": 0,
    "created_at": "2025-12-13T19:56:56.283Z",
    "updated_at": "2025-12-13T19:56:57.502Z"
  },
  "message": "Player logged in successfully"
}
```

---

### Test Summary

| Test Case | Status | Result |
|-----------|--------|--------|
| New player with starter pack | ✅ | Tank and 2 fish minted, IDs coherent |
| Second player registration | ✅ | IDs continue consecutively (tank: 2, fish: 3-4) |
| Existing player (idempotency) | ✅ | No duplicate starter pack minted |
| Manual DB deletion handling | ✅ | Counters reset correctly, starts from 1 |

**Total:** 4/4 tests passed ✅

---

## 📸 Screenshots (if applicable)

N/A - Backend API changes, no UI impact

---

## 🗒️ Additional Notes

### Technical Considerations

1. **ID Generation Strategy**: 
   - Uses global in-memory counters synchronized with Supabase MAX(id)
   - Syncs before first use and detects manual database deletions
   - Prevents ID conflicts by always using higher value between memory and DB
   - Tracks last known DB state to detect when DB is emptied

2. **Error Handling**:
   - On-chain minting failures stop the process before Supabase writes
   - Supabase save failures trigger rollback to delete already-saved records
   - Race conditions handled with PostgreSQL unique violation detection
   - Idempotent behavior: duplicate requests from same owner are treated as success

3. **Rollback Mechanism**:
   - If Supabase save fails after successful on-chain minting, attempts to delete saved records
   - Best-effort cleanup that logs errors but doesn't throw (to prevent cascading failures)
   - On-chain mints are irreversible (by design), but off-chain records are cleaned up

4. **Starter Pack Contents**:
   - Tank: capacity=10, name="Starter Tank"
   - Fish: species="Starter Fish", random DNA for each, image_url="/images/fish/starter-fish.png"
   - Fish count updated to 2 after successful minting

### Files Modified/Created

- ✨ `src/core/types/dojo-types.ts` (modified - added interfaces)
- 📝 `src/core/types/index.ts` (modified - re-exported new types)
- 📝 `src/core/utils/dojo-client.ts` (modified - ID generation and sync)
- 📝 `src/services/player.service.ts` (modified - starter pack minting)

### Dependencies

- Uses existing `@supabase/supabase-js` for database operations
- Uses `@/core/utils/dojo-client` for on-chain minting stubs
- Follows error handling patterns from existing services
- Uses custom error classes: `ValidationError`, `OnChainError`, `ConflictError`

### Next Steps

- [ ] Add unit tests for `mintStarterPack()` method
- [ ] Add integration tests for starter pack minting endpoint
- [ ] Implement real Dojo contract calls (replace stubs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated starter pack minting during player registration, creating a tank and two randomized fish for new accounts.
  * Enhanced minting operations with improved synchronization between on-chain transactions and database records.
  * Added comprehensive validation, conflict detection, and error handling to ensure consistent state between on-chain and off-chain systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->