### PR TITLE
GET /fish/:id endpoint to retrieve detailed information about a specific fish by its ID

### DIFF
--- a/src/api/fish.routes.ts
+++ b/src/api/fish.routes.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Fish Routes
+ * 
+ * Route definitions for fish endpoints.
+ */
+
+import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import { getFishById } from '@/controllers/fish.controller';
+
+/**
+ * Registers fish routes with the Fastify instance.
+ * 
+ * @param app - Fastify instance
+ * @param options - Route options
+ */
+export async function fishRoutes(
+  app: FastifyInstance,
+  options: FastifyPluginOptions
+): Promise<void> {
+  // GET /fish/:id - Get fish details by ID
+  app.get('/fish/:id', getFishById);
+}
+

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@
 import type { FastifyInstance } from 'fastify';
 import { authRoutes } from '@/api/auth.routes';
 import { playerRoutes } from '@/api/player.routes';
+import { fishRoutes } from '@/api/fish.routes';
 
 /**
  * Registers all API routes with the Fastify instance.
@@ -18,7 +19,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   // Register route modules here
   await app.register(authRoutes, { prefix: '/api' });
   await app.register(playerRoutes, { prefix: '/api' });
-  // await app.register(fishRoutes, { prefix: '/api/fish' });
+  await app.register(fishRoutes, { prefix: '/api' });
 
   // Placeholder route for testing
   app.get('/api', async () => {

--- a/src/controllers/fish.controller.ts
+++ b/src/controllers/fish.controller.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Fish Controller
+ * 
+ * Request handlers for fish endpoints.
+ */
+
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import type { ControllerResponse } from '@/core/types/controller-response';
+import { createSuccessResponse, createErrorResponse } from '@/core/responses';
+import { FishService } from '@/services/fish.service';
+import type { Fish } from '@/models/fish.model';
+
+const fishService = new FishService();
+
+/**
+ * GET /fish/:id
+ * 
+ * Retrieves detailed information about a specific fish by its ID.
+ * 
+ * @param request - Fastify request with id parameter
+ * @param reply - Fastify reply
+ * @returns Fish data or error response
+ */
+export async function getFishById(
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+): Promise<ControllerResponse<Fish>> {
+  try {
+    const { id } = request.params;
+    const fishId = parseInt(id, 10);
+    
+    // Basic validation before service call (service does stricter validation)
+    if (isNaN(fishId)) {
+      throw new Error('Invalid fish ID format');
+    }
+
+    const fish = await fishService.getFishById(fishId);
+
+    return createSuccessResponse(
+      fish,
+      'Fish retrieved successfully'
+    );
+  } catch (error) {
+    return createErrorResponse(error);
+  }
+}
+

--- a/src/core/utils/dojo-client.ts
+++ b/src/core/utils/dojo-client.ts
@@ -18,6 +18,7 @@ import {
   DecorationKind,
   MintTankResult,
   MintFishResult,
+  FishOnChain,
 } from '../types';
 
 // Flag to track if client is initialized
@@ -383,6 +384,33 @@ export async function getFishFamilyTree(fishId: number): Promise<FishFamilyTree>
 
   logInfo(`Fish family tree retrieved (stub): fish=${fishId}, generations=${familyTree.generation_count}`);
   return familyTree;
+}
+
+/**
+ * Gets fish data from on-chain.
+ * STUB: Returns mock fish data.
+ * 
+ * @param fishId - ID of the fish
+ * @returns FishOnChain data
+ */
+export async function getFishOnChain(fishId: number): Promise<FishOnChain> {
+  logDebug(`[STUB] getFishOnChain called with fishId: ${fishId}`);
+  
+  // TODO: Replace with real Dojo contract call
+  // const result = await contract.call('get_fish', [fishId]);
+  
+  // Mock data
+  const fishOnChain: FishOnChain = {
+    id: fishId,
+    xp: 100, // Mock XP
+    state: 'Adult',
+    hunger: 50, // 0-100
+    isReadyToBreed: true,
+    dna: generateRandomDna(),
+  };
+
+  logInfo(`Fish on-chain data retrieved (stub): fish=${fishId}`);
+  return fishOnChain;
 }
 
 // ============================================================================

--- a/src/services/fish.service.ts
+++ b/src/services/fish.service.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Fish Service
+ * 
+ * Handles business logic for fish operations including retrieval,
+ * and synchronization between Supabase and on-chain data.
+ */
+
+// ============================================================================
+// IMPORTS
+// ============================================================================
+
+import { ValidationError, NotFoundError, OnChainError } from '@/core/errors';
+import { getSupabaseClient } from '@/core/utils/supabase-client';
+import { logError } from '@/core/utils/logger';
+import { getFishOnChain } from '@/core/utils/dojo-client';
+import type { Fish } from '@/models/fish.model';
+
+// ============================================================================
+// FISH SERVICE
+// ============================================================================
+
+/**
+ * Service for managing fish data and operations.
+ */
+export class FishService {
+  
+  // ============================================================================
+  // FISH RETRIEVAL
+  // ============================================================================
+
+  /**
+   * Retrieves a fish by its ID.
+   * 
+   * Combines data from:
+   * 1. Off-chain (Supabase): owner, species, image, creation date
+   * 2. On-chain (Dojo): xp, state, hunger, breeding status, dna
+   * 
+   * @param id - Fish ID
+   * @returns Complete Fish data
+   * @throws {ValidationError} If ID is invalid
+   * @throws {NotFoundError} If fish doesn't exist
+   */
+  async getFishById(id: number): Promise<Fish> {
+    // Validate ID
+    if (!id || id <= 0 || !Number.isInteger(id)) {
+      throw new ValidationError('Invalid fish ID');
+    }
+
+    const supabase = getSupabaseClient();
+
+    // 1. Get off-chain data from Supabase
+    const { data: fishOffChain, error } = await supabase
+      .from('fish')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        throw new NotFoundError(`Fish with ID ${id} not found`);
+      }
+      throw new Error(`Database error: ${error.message}`);
+    }
+
+    if (!fishOffChain) {
+      throw new NotFoundError(`Fish with ID ${id} not found`);
+    }
+
+    // 2. Get on-chain data from Dojo
+    try {
+      const fishOnChain = await getFishOnChain(id);
+
+      // 3. Combine data
+      const fish: Fish = {
+        // On-chain data
+        id: fishOnChain.id,
+        xp: fishOnChain.xp,
+        state: fishOnChain.state,
+        hunger: fishOnChain.hunger,
+        isReadyToBreed: fishOnChain.isReadyToBreed,
+        dna: fishOnChain.dna,
+        
+        // Off-chain data
+        owner: fishOffChain.owner,
+        species: fishOffChain.species,
+        imageUrl: fishOffChain.image_url, // Map snake_case to camelCase
+        createdAt: new Date(fishOffChain.created_at), // Convert string to Date
+      };
+
+      return fish;
+    } catch (error) {
+      logError(`Failed to get on-chain data for fish ${id}`, error);
+      // If on-chain fetch fails, we could either:
+      // a) Throw error (strict consistency)
+      // b) Return partial data (availability over consistency)
+      // For now, we throw OnChainError as the fish is fundamentally an on-chain asset
+      throw new OnChainError(
+        `Failed to retrieve on-chain data for fish ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+}
+


### PR DESCRIPTION

## 🔗 Related Issue
Closes #36

---

## 📝 Description
This PR implements the GET /fish/:id endpoint to retrieve detailed information about a specific fish by its ID. The endpoint combines off-chain data from Supabase (owner, species, imageUrl, createdAt) with on-chain data from Dojo contract (xp, state, hunger, isReadyToBreed, dna) to return a complete Fish object.

The implementation follows the existing patterns in the codebase:
- Service layer handles business logic and data combination
- Controller handles HTTP request/response
- Routes registered in the main API router
- Stub function added for on-chain data retrieval (will be replaced with real Dojo calls)

---

## 🔄 Changes Made
- [x] Added `getFishOnChain` stub function in `dojo-client.ts` to retrieve on-chain fish data
- [x] Created `FishService` class with `getFishById` method that combines off-chain and on-chain data
- [x] Created `fish.controller.ts` with `getFishById` handler for the GET endpoint
- [x] Created `fish.routes.ts` to register the GET /fish/:id route
- [x] Registered fish routes in `api/index.ts` with `/api` prefix

---

## 🧪 Tests Applied

### Manual Testing
All tests were performed via curl commands against the local server running on port 4000:

1. **Player Registration & Starter Pack Creation:**
   ```bash
   curl -X POST http://localhost:4000/api/auth/login \
     -H "Content-Type: application/json" \
     -d '{"address": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}'
   ```
   ✅ Result: Successfully registered player and created starter pack with 2 fish (IDs 1 and 2)

2. **Get Fish by ID - Valid IDs:**
   ```bash
   curl http://localhost:4000/api/fish/1
   curl http://localhost:4000/api/fish/2
   ```
   ✅ Result: Both requests returned complete fish data including:
   - Off-chain data: owner, species, imageUrl, createdAt
   - On-chain data: xp (100), state ("Adult"), hunger (50), isReadyToBreed (true), dna (unique per fish)

3. **Get Fish by ID - Non-existent Fish:**
   ```bash
   curl http://localhost:4000/api/fish/3
   ```
   ✅ Result: Returned proper error response:
   ```json
   {"success":false,"error":{"type":"NotFoundError","message":"Fish with ID 3 not found","code":404}}
   ```

4. **Get Fish by ID - Invalid Format:**
   ```bash
   curl http://localhost:4000/api/fish/
   curl http://localhost:4000/api/fish/d
   ```
   ✅ Result: Returned validation error for invalid ID format

### Test Results Summary
- ✅ Endpoint correctly retrieves and combines off-chain and on-chain data
- ✅ Proper error handling for non-existent fish (404 NotFoundError)
- ✅ Input validation for invalid ID formats
- ✅ Response format follows ControllerResponse<T> standard
- ✅ All required fields present in response (id, xp, state, hunger, isReadyToBreed, dna, owner, species, imageUrl, createdAt)

---

## 📸 Screenshots (if applicable)
N/A (API endpoint - no UI changes)

---

## 🗒️ Additional Notes
- The `getFishOnChain` function currently returns mock data as a stub. This will be replaced with actual Dojo contract calls when the contracts are deployed.
- The endpoint follows the same error handling patterns as other endpoints in the codebase (using ValidationError, NotFoundError, etc.)
- Data mapping is handled in the service layer, converting snake_case from Supabase to camelCase for the API response.
- The endpoint is accessible at `GET /api/fish/:id`
- All changes follow the project's coding standards and naming conventions (kebab-case for files, camelCase for variables)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve individual fish details by ID. The endpoint provides comprehensive fish information by combining data from multiple sources, giving users access to complete fish records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->