### PR TITLE
Implements the GET /tank/:id endpoint to retrieve detailed information about a specific tank by its ID.

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ import type { FastifyInstance } from 'fastify';
 import { authRoutes } from '@/api/auth.routes';
 import { playerRoutes } from '@/api/player.routes';
 import { fishRoutes } from '@/api/fish.routes';
+import { tankRoutes } from '@/api/tank.routes';
 
 /**
  * Registers all API routes with the Fastify instance.
@@ -20,6 +21,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await app.register(authRoutes, { prefix: '/api' });
   await app.register(playerRoutes, { prefix: '/api' });
   await app.register(fishRoutes, { prefix: '/api' });
+  await app.register(tankRoutes, { prefix: '/api' });
 
   // Placeholder route for testing
   app.get('/api', async () => {

--- a/src/api/tank.routes.ts
+++ b/src/api/tank.routes.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Tank Routes
+ * 
+ * Route definitions for tank endpoints.
+ */
+
+import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import { getTankById } from '@/controllers/tank.controller';
+
+/**
+ * Registers tank routes with the Fastify instance.
+ * 
+ * @param app - Fastify instance
+ * @param options - Route options
+ */
+export async function tankRoutes(
+  app: FastifyInstance,
+  _options: FastifyPluginOptions
+): Promise<void> {
+  // GET /tank/:id - Get tank details by ID
+  app.get('/tank/:id', getTankById);
+}
+

--- a/src/controllers/tank.controller.ts
+++ b/src/controllers/tank.controller.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Tank Controller
+ * 
+ * Request handlers for tank endpoints.
+ */
+
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import type { ControllerResponse } from '@/core/types/controller-response';
+import { createSuccessResponse, createErrorResponse } from '@/core/responses';
+import { TankService } from '@/services/tank.service';
+import type { Tank } from '@/models/tank.model';
+import type { FishSummary } from '@/models/fish.model';
+
+const tankService = new TankService();
+
+/**
+ * GET /tank/:id
+ * 
+ * Retrieves detailed information about a specific tank by its ID.
+ * Includes a summary list of fish belonging to the tank's owner (off-chain data only).
+ * For complete fish data with on-chain information, use GET /api/fish/:id.
+ * 
+ * @param request - Fastify request with id parameter
+ * @param reply - Fastify reply
+ * @returns Tank data with fish summary list or error response
+ */
+export async function getTankById(
+  request: FastifyRequest<{ Params: { id: string } }>,
+  _reply: FastifyReply
+): Promise<ControllerResponse<Tank & { fish: FishSummary[] }>> {
+  try {
+    const { id } = request.params;
+    const tankId = parseInt(id, 10);
+    
+    // Basic validation before service call
+    if (isNaN(tankId)) {
+      throw new Error('Invalid tank ID format');
+    }
+
+    const tank = await tankService.getTankById(tankId);
+
+    return createSuccessResponse(
+      tank,
+      'Tank retrieved successfully'
+    );
+  } catch (error) {
+    return createErrorResponse(error);
+  }
+}
+

--- a/src/core/utils/dojo-client.ts
+++ b/src/core/utils/dojo-client.ts
@@ -19,6 +19,7 @@ import {
   MintTankResult,
   MintFishResult,
   FishOnChain,
+  TankOnChain,
 } from '../types';
 
 // Flag to track if client is initialized
@@ -449,6 +450,31 @@ export async function mintTank(
     tx_hash: txHash,
     tank_id: tankId,
   };
+}
+
+/**
+ * Gets tank data from on-chain.
+ * STUB: Returns mock tank data.
+ * 
+ * @param tankId - ID of the tank
+ * @returns TankOnChain data
+ */
+export async function getTankOnChain(tankId: number): Promise<TankOnChain> {
+  logDebug(`[STUB] getTankOnChain called with tankId: ${tankId}`);
+  
+  // TODO: Replace with real Dojo contract call
+  // const result = await contract.call('get_tank', [tankId]);
+  
+  // Mock data - owner will be overridden by the service with the real owner from DB if needed,
+  // or we assume the caller knows it. For now returning a placeholder.
+  const tankOnChain: TankOnChain = {
+    id: tankId,
+    owner: '0x0', // Placeholder, service should handle consistency
+    capacity: 10, // Default capacity
+  };
+
+  logInfo(`Tank on-chain data retrieved (stub): tank=${tankId}`);
+  return tankOnChain;
 }
 
 /**

--- a/src/models/fish.model.ts
+++ b/src/models/fish.model.ts
@@ -21,6 +21,15 @@ export interface Fish extends FishOnChain, Omit<FishOffChain, 'id'> {
   id: number;
 }
 
+/**
+ * Summary of fish data without on-chain information.
+ * Used for lists where full on-chain data is not needed.
+ * For complete fish data, use the Fish interface or GET /api/fish/:id endpoint.
+ */
+export interface FishSummary extends FishOffChain {
+  id: number;
+}
+
 export interface CreateFishDto {
   id: number;
   owner: string;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -10,6 +10,7 @@ export type {
 
 export type {
   Fish,
+  FishSummary,
   CreateFishDto,
   UpdateFishDto,
 } from './fish.model';

--- a/src/services/tank.service.ts
+++ b/src/services/tank.service.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Tank Service
+ * 
+ * Handles business logic for tank operations including retrieval,
+ * and synchronization between Supabase and on-chain data.
+ */
+
+// ============================================================================
+// IMPORTS
+// ============================================================================
+
+import { ValidationError, NotFoundError, OnChainError } from '@/core/errors';
+import { getSupabaseClient } from '@/core/utils/supabase-client';
+import { logError } from '@/core/utils/logger';
+import { getTankOnChain } from '@/core/utils/dojo-client';
+import type { Tank } from '@/models/tank.model';
+import type { FishSummary } from '@/models/fish.model';
+
+// ============================================================================
+// TANK SERVICE
+// ============================================================================
+
+/**
+ * Service for managing tank data and operations.
+ */
+export class TankService {
+  
+  // ============================================================================
+  // TANK RETRIEVAL
+  // ============================================================================
+
+  /**
+   * Retrieves a tank by its ID.
+   * 
+   * Combines data from:
+   * 1. Off-chain (Supabase): owner, name, creation date
+   * 2. On-chain (Dojo): capacity
+   * 3. Related data: list of fish owned by the tank owner
+   * 
+   * @param id - Tank ID
+   * @returns Complete Tank data including fish summary list (without on-chain data)
+   * @throws {ValidationError} If ID is invalid
+   * @throws {NotFoundError} If tank doesn't exist
+   */
+  async getTankById(id: number): Promise<Tank & { fish: FishSummary[] }> {
+    // Validate ID
+    if (!id || id <= 0 || !Number.isInteger(id)) {
+      throw new ValidationError('Invalid tank ID');
+    }
+
+    const supabase = getSupabaseClient();
+
+    // 1. Get off-chain data from Supabase
+    const { data: tankOffChain, error } = await supabase
+      .from('tanks')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        throw new NotFoundError(`Tank with ID ${id} not found`);
+      }
+      throw new Error(`Database error: ${error.message}`);
+    }
+
+    if (!tankOffChain) {
+      throw new NotFoundError(`Tank with ID ${id} not found`);
+    }
+
+    // 2. Get on-chain data from Dojo
+    let tankOnChain;
+    try {
+      tankOnChain = await getTankOnChain(id);
+    } catch (error) {
+      logError(`Failed to get on-chain data for tank ${id}`, error);
+      throw new OnChainError(
+        `Failed to retrieve on-chain data for tank ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+
+    // 3. Get fish list for this owner
+    // Since we don't have tank_id in fish table yet, we assume all fish of the owner are in their tank
+    // (Simplification for now based on current schema)
+    const { data: fishList, error: fishError } = await supabase
+      .from('fish')
+      .select('*')
+      .eq('owner', tankOffChain.owner);
+
+    if (fishError) {
+      logError(`Failed to get fish list for tank owner ${tankOffChain.owner}`, fishError);
+      // Return empty array if error occurs
+    }
+
+    // Map Supabase fish to FishSummary (off-chain data only)
+    // For complete fish data with on-chain info, use GET /api/fish/:id endpoint
+    const fish: FishSummary[] = (fishList || []).map(f => ({
+      id: f.id,
+      owner: f.owner,
+      species: f.species,
+      imageUrl: f.image_url,
+      createdAt: new Date(f.created_at),
+    }));
+
+    // 4. Combine data
+    const tank: Tank & { fish: FishSummary[] } = {
+      // On-chain data
+      id: tankOnChain.id,
+      capacity: tankOnChain.capacity,
+      
+      // Off-chain data
+      owner: tankOffChain.owner,
+      name: tankOffChain.name,
+      createdAt: new Date(tankOffChain.created_at),
+      
+      // Relations
+      fish: fish
+    };
+
+    return tank;
+  }
+}
+


### PR DESCRIPTION

## 🔗 Related Issue
Closes #37

---

## 📝 Description

Implements the GET /tank/:id endpoint to retrieve detailed information about a specific tank by its ID. The endpoint combines on-chain data (from Dojo/Starknet) and off-chain data (from Supabase), and includes a summary list of fish belonging to the tank's owner.

Key features:
- Retrieves complete tank data (on-chain capacity + off-chain metadata)
- Returns fish list with off-chain data only (using new `FishSummary` type)
- Validates tank ID and returns appropriate errors (404 for not found, 400 for invalid ID)
- Follows project standards: uses `ControllerResponse<T>`, proper error handling, and standardized response format

---

## 🔄 Changes Made
- [x] Added `getTankOnChain()` stub function in `dojo-client.ts` to fetch on-chain tank data
- [x] Created `FishSummary` type in `fish.model.ts` for fish list views (off-chain data only)
- [x] Exported `FishSummary` type in `models/index.ts`
- [x] Implemented `TankService.getTankById()` method that combines on-chain and off-chain data
- [x] Created `tank.controller.ts` with `getTankById` handler following project standards
- [x] Created `tank.routes.ts` with GET /tank/:id route definition
- [x] Registered tank routes in `api/index.ts`

---

## 🧪 Tests Applied

### Manual Testing
The endpoint was tested manually using curl:

**Test 1: Get existing tank**
```bash
curl -X GET http://localhost:4000/api/tank/1 | jq
```
**Result:** ✅ Returns 200 with complete tank data including:
- Tank on-chain data (id, capacity)
- Tank off-chain data (owner, name, createdAt)
- Fish summary list (2 fish with off-chain data only)

**Test 2: Get non-existent tank**
```bash
curl -X GET http://localhost:4000/api/tank/999 | jq
```
**Result:** ✅ Returns 404 with proper error message: "Tank with ID 999 not found"

**Test 3: Invalid ID format**
```bash
curl -X GET http://localhost:4000/api/tank/abc | jq
```
**Result:** ✅ Returns 400 with validation error

**Test 4: Compare with individual fish endpoint**
```bash
curl -X GET http://localhost:4000/api/fish/1 | jq
```
**Result:** ✅ Confirmed that fish in tank list (FishSummary) contains only off-chain data, while individual fish endpoint (Fish) includes complete on-chain data (xp, state, hunger, etc.)

### Test Results Summary
- ✅ Successfully retrieves tank with valid ID
- ✅ Returns proper 404 for non-existent tanks
- ✅ Returns proper 400 for invalid ID formats
- ✅ FishSummary type correctly excludes on-chain data from list view
- ✅ Response format follows project standards (ControllerResponse<T>)

---

## 📸 Screenshots (if applicable)
N/A - Backend API endpoint only

---

## 🗒️ Additional Notes

**Design Decision: FishSummary Type**
- Created `FishSummary` type to avoid N+1 queries when fetching fish lists in tanks
- Fish list in tank response contains only off-chain data (id, owner, species, imageUrl, createdAt)
- For complete fish data with on-chain information (xp, state, hunger, etc.), clients should use GET /api/fish/:id endpoint
- This approach is more efficient and semantically correct (a list is a summary, not full details)

**Follows Project Standards:**
- ✅ Uses `ControllerResponse<T>` return type
- ✅ Uses `createSuccessResponse()` and `createErrorResponse()`
- ✅ Proper error handling with custom error classes
- ✅ All files follow kebab-case naming convention
- ✅ JSDoc comments in English
- ✅ One commit per file following conventional commits
