### PR TITLE
Feat/status endpoint

### DIFF
--- a/src/api/health.routes.ts
+++ b/src/api/health.routes.ts
@@ -5,7 +5,7 @@
  */
 
 import type { FastifyInstance } from 'fastify';
-import { getHealth } from '@/controllers/health.controller';
+import { getHealth, getStatus } from '@/controllers/health.controller';
 
 /**
  * Registers health routes with the Fastify instance.
@@ -14,5 +14,6 @@ import { getHealth } from '@/controllers/health.controller';
  */
 export async function healthRoutes(app: FastifyInstance): Promise<void> {
   app.get('/health', getHealth);
+  app.get('/status', getStatus);
 }
 

--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -7,6 +7,8 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { ControllerResponse } from '@/core/types/controller-response';
 import { createSuccessResponse } from '@/core/responses';
+import { validateSupabaseConnection } from '@/core/utils/supabase-client';
+import { validateDojoConnection, initializeDojoClient } from '@/core/utils/dojo-client';
 import pkg from '../../package.json';
 
 /**
@@ -17,6 +19,26 @@ interface HealthData {
   version: string;
   timestamp: string;
   uptime: number;
+}
+
+/**
+ * Service status information
+ */
+interface ServiceStatus {
+  name: string;
+  status: 'healthy' | 'unhealthy';
+  message?: string;
+}
+
+/**
+ * Status endpoint response data
+ */
+interface StatusData {
+  status: 'ok';
+  version: string;
+  timestamp: string;
+  uptime: number;
+  services: ServiceStatus[];
 }
 
 /**
@@ -49,6 +71,60 @@ export async function getHealth(
     version: pkg.version,
     timestamp: new Date().toISOString(),
     uptime
+  });
+}
+
+/**
+ * GET /status endpoint.
+ * 
+ * Returns comprehensive system status including health checks for all services.
+ * 
+ * @param request - Fastify request
+ * @param _reply - Fastify reply
+ * @returns ControllerResponse<StatusData>
+ */
+export async function getStatus(
+  request: FastifyRequest,
+  _reply: FastifyReply
+): Promise<ControllerResponse<StatusData>> {
+  const startTime = request.server.startTime || Date.now();
+  const uptime = Math.floor((Date.now() - startTime) / 1000);
+
+  // Ensure Dojo client is initialized before checking
+  initializeDojoClient();
+
+  // Check Supabase connection
+  const supabaseHealthy = await validateSupabaseConnection();
+  const supabaseStatus: ServiceStatus = supabaseHealthy
+    ? {
+        name: 'Supabase',
+        status: 'healthy'
+      }
+    : {
+        name: 'Supabase',
+        status: 'unhealthy',
+        message: 'Connection failed or timeout'
+      };
+
+  // Check Dojo/Starknet connection
+  const dojoHealthy = await validateDojoConnection(5000);
+  const dojoStatus: ServiceStatus = dojoHealthy
+    ? {
+        name: 'Dojo/Starknet',
+        status: 'healthy'
+      }
+    : {
+        name: 'Dojo/Starknet',
+        status: 'unhealthy',
+        message: 'Connection failed or timeout'
+      };
+
+  return createSuccessResponse({
+    status: 'ok',
+    version: pkg.version,
+    timestamp: new Date().toISOString(),
+    uptime,
+    services: [supabaseStatus, dojoStatus]
   });
 }
 

--- a/tests/controllers/health.controller.status.test.ts
+++ b/tests/controllers/health.controller.status.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @fileoverview Tests for Health Controller - Status Endpoint
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { getStatus } from '@/controllers/health.controller';
+import { validateSupabaseConnection } from '@/core/utils/supabase-client';
+import { validateDojoConnection, initializeDojoClient } from '@/core/utils/dojo-client';
+import pkg from '../../package.json';
+
+// Mock dependencies
+vi.mock('@/core/utils/supabase-client', () => ({
+  validateSupabaseConnection: vi.fn(),
+}));
+
+vi.mock('@/core/utils/dojo-client', () => ({
+  validateDojoConnection: vi.fn(),
+  initializeDojoClient: vi.fn(),
+}));
+
+vi.mock('../../package.json', () => ({
+  default: {
+    version: '1.0.0',
+  },
+}));
+
+describe('Health Controller - getStatus', () => {
+  let mockRequest: Partial<FastifyRequest>;
+  let mockReply: Partial<FastifyReply>;
+  const mockStartTime = Date.now() - 5000; // 5 seconds ago
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRequest = {
+      server: {
+        startTime: mockStartTime,
+      } as any,
+    };
+
+    mockReply = {};
+  });
+
+  describe('successful status check', () => {
+    it('should return success response with all services healthy', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.message).toBe('Operation successful');
+      expect(response.data).toBeDefined();
+      expect(response.data.status).toBe('ok');
+      expect(response.data.version).toBe(pkg.version);
+      expect(response.data.timestamp).toBeDefined();
+      expect(response.data.uptime).toBeGreaterThanOrEqual(4);
+      expect(response.data.services).toHaveLength(2);
+      expect(response.data.services[0]).toEqual({
+        name: 'Supabase',
+        status: 'healthy'
+      });
+      expect(response.data.services[1]).toEqual({
+        name: 'Dojo/Starknet',
+        status: 'healthy'
+      });
+    });
+
+    it('should initialize Dojo client before checking', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(initializeDojoClient).toHaveBeenCalled();
+    });
+  });
+
+  describe('service health checks', () => {
+    it('should return unhealthy status when Supabase is down', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(false);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response.data.services[0]).toEqual({
+        name: 'Supabase',
+        status: 'unhealthy',
+        message: 'Connection failed or timeout'
+      });
+      expect(response.data.services[1]).toEqual({
+        name: 'Dojo/Starknet',
+        status: 'healthy'
+      });
+    });
+
+    it('should return unhealthy status when Dojo/Starknet is down', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(false);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response.data.services[0]).toEqual({
+        name: 'Supabase',
+        status: 'healthy'
+      });
+      expect(response.data.services[1]).toEqual({
+        name: 'Dojo/Starknet',
+        status: 'unhealthy',
+        message: 'Connection failed or timeout'
+      });
+    });
+
+    it('should return unhealthy status when both services are down', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(false);
+      vi.mocked(validateDojoConnection).mockResolvedValue(false);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response.data.services[0].status).toBe('unhealthy');
+      expect(response.data.services[1].status).toBe('unhealthy');
+    });
+  });
+
+  describe('response structure', () => {
+    it('should include all required fields', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response.data).toHaveProperty('status');
+      expect(response.data).toHaveProperty('version');
+      expect(response.data).toHaveProperty('timestamp');
+      expect(response.data).toHaveProperty('uptime');
+      expect(response.data).toHaveProperty('services');
+      expect(Array.isArray(response.data.services)).toBe(true);
+    });
+
+    it('should return timestamp in ISO format', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      const timestamp = response.data.timestamp;
+      expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(() => new Date(timestamp)).not.toThrow();
+    });
+
+    it('should use standardized response format', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response).toHaveProperty('success');
+      expect(response).toHaveProperty('data');
+      expect(response).toHaveProperty('message');
+      expect(response.success).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing startTime gracefully', async () => {
+      mockRequest.server = {} as any;
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      const response = await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(response.data.uptime).toBeGreaterThanOrEqual(0);
+      expect(response.data.uptime).toBeLessThanOrEqual(1);
+    });
+
+    it('should call validateDojoConnection with timeout', async () => {
+      vi.mocked(validateSupabaseConnection).mockResolvedValue(true);
+      vi.mocked(validateDojoConnection).mockResolvedValue(true);
+
+      await getStatus(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply
+      );
+
+      expect(validateDojoConnection).toHaveBeenCalledWith(5000);
+    });
+  });
+});
+


### PR DESCRIPTION

## 🔗 Related Issue
Closes #19

---

## 📝 Description
Implemented comprehensive `/status` endpoint that verifies connections to external services (Supabase and Dojo/Starknet). This endpoint provides detailed health information about all system components, making it useful for monitoring and debugging.

The endpoint follows the same standardized response format as other endpoints and includes system information (API version, timestamp, uptime) along with individual service status indicators.

---

## 🔄 Changes Made
- [x] Added `validateDojoConnection()` function in `dojo-client.ts` with timeout support
- [x] Implemented `getStatus()` endpoint in `health.controller.ts` with service health checks
- [x] Registered `GET /api/status` route in `health.routes.ts`
- [x] Created comprehensive test suite with 10 test cases covering all scenarios
- [x] Endpoint uses `createSuccessResponse` for standardized format
- [x] Includes API version, timestamp, uptime, and individual service statuses
- [x] Each service has its own status indicator (healthy/unhealthy) with optional error messages

---

## 🧪 Testing

### Unit Tests
Created comprehensive test suite covering:
- ✅ Success response with all services healthy
- ✅ Individual service failures (Supabase, Dojo/Starknet)
- ✅ Both services unhealthy scenario
- ✅ Response structure validation
- ✅ Timestamp format validation
- ✅ Edge cases (missing startTime, timeout handling)
- ✅ Dojo client initialization verification

**Test Results:**
```bash
✓ tests/controllers/health.controller.status.test.ts (10 tests) 3ms
Test Files  1 passed (1)
Tests  10 passed (10)
```

### Manual Testing (Postman)

**Request:**
```
GET http://localhost:3000/api/status
```

**Expected Response (All Services Healthy):**
```json
{
  "success": true,
  "data": {
    "status": "ok",
    "version": "1.0.0",
    "timestamp": "2025-01-09T16:07:35.789Z",
    "uptime": 123,
    "services": [
      {
        "name": "Supabase",
        "status": "healthy"
      },
      {
        "name": "Dojo/Starknet",
        "status": "healthy"
      }
    ]
  },
  "message": "Operation successful"
}
```

**Expected Response (Service Unhealthy):**
```json
{
  "success": true,
  "data": {
    "status": "ok",
    "version": "1.0.0",
    "timestamp": "2025-01-09T16:07:35.789Z",
    "uptime": 123,
    "services": [
      {
        "name": "Supabase",
        "status": "unhealthy",
        "message": "Connection failed or timeout"
      },
      {
        "name": "Dojo/Starknet",
        "status": "healthy"
      }
    ]
  },
  "message": "Operation successful"
}
```

**Response Fields:**
- `success`: Always `true` (standardized format)
- `data.status`: Overall system status (`"ok"`)
- `data.version`: API version from `package.json`
- `data.timestamp`: Current timestamp in ISO format
- `data.uptime`: Server uptime in seconds since startup
- `data.services`: Array of service status objects
  - `name`: Service name (Supabase, Dojo/Starknet)
  - `status`: `"healthy"` or `"unhealthy"`
  - `message`: Optional error message (only present when unhealthy)
- `message`: Success message

---

## 📸 Screenshots (if applicable)
N/A (API endpoint, no UI changes)

---

## 🗒️ Additional Notes

### Implementation Details

**Dojo/Starknet Connection Validation:**
- Uses `RpcProvider` from `starknet` package to verify RPC connectivity
- Implements 5-second timeout for connection checks
- Handles stub mode gracefully (when credentials are missing, considers it healthy)
- Automatically initializes Dojo client if not already initialized

**Supabase Connection Validation:**
- Reuses existing `validateSupabaseConnection()` function
- Performs lightweight health check query
- Handles network errors and timeouts appropriately

**Service Status Structure:**
- Each service returns `healthy` or `unhealthy` status
- Error messages only included when service is unhealthy
- Follows TypeScript strict optional property types

### Architecture
- Follows project conventions: controller → routes → registration pattern
- Uses standardized response format (`createSuccessResponse`)
- Maintains consistency with other endpoints under `/api` prefix
- Proper TypeScript typing with `ControllerResponse<StatusData>`

### Future Considerations
- Easy to extend with additional services (e.g., Redis, external APIs)
- Timeout values are configurable (currently 5000ms for Dojo)
- Service status can be extended with additional metadata if needed
