### PR TITLE
Sync queue service into all on-chain operations to ensure all blockchain transactions

### DIFF
--- a/tests/services/decoration.service.test.ts
+++ b/tests/services/decoration.service.test.ts
@@ -18,6 +18,12 @@ vi.mock('@/core/utils/logger', () => ({
   logError: vi.fn(),
 }));
 
+vi.mock('@/services/sync.service', () => ({
+  SyncService: vi.fn().mockImplementation(() => ({
+    addToSyncQueue: vi.fn().mockResolvedValue({}),
+  })),
+}));
+
 // Now import after mocks
 import { DecorationService } from '@/services/decoration.service';
 import { ValidationError, NotFoundError, ConflictError, OnChainError } from '@/core/errors';


### PR DESCRIPTION
## 🔗 Related Issue
Closes #17

---

## 📝 Description
This PR integrates the sync queue service into all on-chain operations to ensure all blockchain transactions are tracked for synchronization and status updates. Every on-chain stub call now results in a sync queue entry with the appropriate `entityType` and `entityId`.

---

## 🔄 Changes Made
- [x] Modified `registerPlayer()` to capture `tx_hash` and add to sync queue with `entityType: 'player'`
- [x] Modified `mintStarterPack()` to add all mint transactions (tank, fish1, fish2) to sync queue
- [x] Refactored `feedFishBatch()` to use `SyncService` instead of direct Supabase inserts
- [x] Modified `breedFish()` to capture `tx_hash` and add to sync queue with `entityType: 'fish'`
- [x] Modified `activateDecoration()` to capture `tx_hash` and add to sync queue with `entityType: 'decoration'`
- [x] Modified `deactivateDecoration()` to capture `tx_hash` and add to sync queue with `entityType: 'decoration'`
- [x] Updated decoration service tests to mock `SyncService`

---

## 🧪 Testing

### Postman Tests Performed

**1. Register Player** (creates sync queue entries for `registerPlayer` + `mintStarterPack`)
```
POST http://localhost:3000/api/auth/login
Body (JSON):
{
  "address": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
}
```
**Expected:** Creates sync queue entries for:
- Player registration (`entity_type: 'player'`)
- Tank mint (`entity_type: 'tank'`)
- Fish 1 mint (`entity_type: 'fish'`)
- Fish 2 mint (`entity_type: 'fish'`)

**2. Feed Fish** (creates sync queue entries for each fish XP + player XP)
```
POST http://localhost:3000/api/fish/feed
Body (JSON):
{
  "fish_ids": [1, 2],
  "owner": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
}
```
**Expected:** Creates sync queue entries for:
- Each fish XP gain (`entity_type: 'fish'`)
- Player XP gain (`entity_type: 'player'`)

**3. Breed Fish** (creates sync queue entry for `breedFish`)
```
POST http://localhost:3000/api/fish/breed
Body (JSON):
{
  "fish1_id": 1,
  "fish2_id": 2,
  "owner": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
}
```
**Expected:** Creates sync queue entry for:
- Breed transaction (`entity_type: 'fish'`)

**4. Activate Decoration**
```
POST http://localhost:3000/api/decoration/1/activate
Body (JSON):
{
  "owner": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
}
```
**Expected:** Creates sync queue entry for:
- Decoration activation (`entity_type: 'decoration'`)

**5. Deactivate Decoration**
```
POST http://localhost:3000/api/decoration/1/deactivate
Body (JSON):
{
  "owner": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
}
```
**Expected:** Creates sync queue entry for:
- Decoration deactivation (`entity_type: 'decoration'`)

### Verification
All transactions were verified in the `sync_queue` table in Supabase, showing entries with:
- Correct `entity_type` values (`player`, `fish`, `tank`, `decoration`)
- Correct `entity_id` values
- `status: 'pending'` (as expected for new transactions)

---

## 📸 Screenshots (if applicable)
Sync queue table showing entries with different entity types and statuses:
- Multiple entries with `entity_type: 'fish'`, `'player'`, `'tank'`, `'decoration'`
- Status values: `pending`, `confirmed`, `failed`
- All transaction hashes properly tracked

---

## 🗒️ Additional Notes
- All sync queue operations use `try-catch` blocks to prevent failures from interrupting the main operation flow
- Errors in sync queue are logged but don't fail the primary on-chain operations
- The sync queue tracks transactions for future status updates via a background process
- All tests pass (66/66) and TypeScript compiles without errors
