### PR TITLE
Row-Level Security (RLS) policies for the `players` table 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ SUPABASE_URL=your_supabase_url_here
 SUPABASE_KEY=your_supabase_anon_key_here
 SUPABASE_DB_URL=your_db_url_here
 SUPABASE_ANON_KEY=your_anon_key_here
+SUPABASE_DB_PASSWORD=your_supabase_password
 
 # =============================================================================
 # STARKNET CONFIGURATION

--- a/supabase/migrations/20251226123330_enable_rls_policies_players.sql
+++ b/supabase/migrations/20251226123330_enable_rls_policies_players.sql
@@ -1,0 +1,68 @@
+-- Enable Row-Level Security (RLS) on players table
+-- This migration implements RLS policies for the players table based on ownership
+-- Note: Backend uses service_role which bypasses RLS, but policies serve as defense-in-depth
+
+-- Enable RLS if not already enabled
+ALTER TABLE players ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist (for idempotency)
+DROP POLICY IF EXISTS "Public read access for players" ON players;
+DROP POLICY IF EXISTS "Public insert access for players" ON players;
+DROP POLICY IF EXISTS "Players can update own record" ON players;
+DROP POLICY IF EXISTS "Players can delete own record" ON players;
+
+-- SELECT Policy: Allow public read access to all players
+-- Anyone can read any player's data (public profile information)
+CREATE POLICY "Public read access for players"
+ON players
+FOR SELECT
+TO public
+USING (true);
+
+-- INSERT Policy: Allow public insert for new player registration
+-- Anyone can create a new player record (for registration)
+CREATE POLICY "Public insert access for players"
+ON players
+FOR INSERT
+TO public
+WITH CHECK (true);
+
+-- UPDATE Policy: Allow users to update only their own player record
+-- Ownership is validated by checking that the address matches the session variable
+-- Note: Backend uses service_role which bypasses RLS, so this policy applies to direct DB access
+-- For direct database access, clients should set app.player_address session variable
+-- Example: SET app.player_address = '0x...';
+CREATE POLICY "Players can update own record"
+ON players
+FOR UPDATE
+TO public
+USING (
+  -- Only allow if address matches session variable (validates ownership)
+  current_setting('app.player_address', true) IS NOT NULL 
+  AND address = current_setting('app.player_address', true)
+)
+WITH CHECK (
+  -- Ensure address matches session variable (validates ownership)
+  -- Also prevents address from being changed (it's the primary key)
+  current_setting('app.player_address', true) IS NOT NULL 
+  AND address = current_setting('app.player_address', true)
+);
+
+-- DELETE Policy: Allow users to delete only their own player record
+-- Ownership is validated by checking the address matches the session variable
+-- Note: Backend uses service_role which bypasses RLS, so this policy applies to direct DB access
+-- For direct database access, clients should set app.player_address session variable
+-- Example: SET app.player_address = '0x...';
+CREATE POLICY "Players can delete own record"
+ON players
+FOR DELETE
+TO public
+USING (
+  -- Only allow if address matches session variable (validates ownership)
+  current_setting('app.player_address', true) IS NOT NULL 
+  AND address = current_setting('app.player_address', true)
+);
+
+-- Add comment documenting RLS policies
+COMMENT ON TABLE players IS 'RLS enabled: Public read/insert, ownership-based update/delete. Backend uses service_role which bypasses RLS.';
+


### PR DESCRIPTION
## 🔗 Related Issue
Closes #69

---

## 📝 Description

This PR implements Row-Level Security (RLS) policies for the `players` table to ensure proper data access control based on ownership. The `players` table had RLS enabled but lacked security policies, causing potential security vulnerabilities.

The implementation adds comprehensive RLS policies that:
- Allow public read access to all player data (profile information)
- Allow public insert for new player registration
- Restrict UPDATE operations to only the player's own record (validated by `address`)
- Restrict DELETE operations to only the player's own record (validated by `address`)

**Important Note:** The backend uses `service_role` which bypasses RLS, so these policies serve as a defense-in-depth layer for direct database access without `service_role`.

---

## 🔄 Changes Made

- [x] Enable RLS on `players` table (if not already enabled)
- [x] Create SELECT policy: Allow public read access to all players
- [x] Create INSERT policy: Allow public insert for new player registration
- [x] Create UPDATE policy: Allow users to update only their own player record (validated by `address` via session variable)
- [x] Create DELETE policy: Allow users to delete only their own player record (validated by `address` via session variable)
- [x] Create migration file: `20251226123330_enable_rls_policies_players.sql`
- [x] Make policies idempotent using `DROP POLICY IF EXISTS`
- [x] Add documentation comments to the migration

---

## 📸 Screenshots (if applicable)
N/A - Database migration only

---

## 🗒️ Additional Notes

**RLS Policy Implementation Details:**

1. **SELECT Policy:** Public access to read any player's data (required for profile viewing)
2. **INSERT Policy:** Public access to create new player records (required for registration)
3. **UPDATE Policy:** Ownership validation using PostgreSQL session variable `app.player_address`. For direct database access (without `service_role`), clients must set this variable before UPDATE operations.
4. **DELETE Policy:** Ownership validation using PostgreSQL session variable `app.player_address`. For direct database access (without `service_role`), clients must set this variable before DELETE operations.

**Migration Safety:**
- All policies use `DROP POLICY IF EXISTS` for idempotency
- Migration has been tested and applied successfully to the remote database
- Backend operations continue to work normally as they use `service_role` which bypasses RLS

**Testing:**
- Migration applied successfully to remote database
- Existing player operations continue to work (verified through service_role bypass)
- Policies are ready for testing with direct database access scenarios