### PR TITLE
Row-Level Security (RLS) policies for the `fish` table

### DIFF
--- a/supabase/migrations/20251226125338_enable_rls_policies_fish.sql
+++ b/supabase/migrations/20251226125338_enable_rls_policies_fish.sql
@@ -1,0 +1,76 @@
+-- Enable Row-Level Security (RLS) on fish table
+-- This migration implements RLS policies for the fish table based on ownership validation
+-- Note: Backend uses service_role which bypasses RLS, but policies serve as defense-in-depth
+
+-- Enable RLS if not already enabled
+ALTER TABLE fish ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist (for idempotency)
+DROP POLICY IF EXISTS "Public read access for fish" ON fish;
+DROP POLICY IF EXISTS "Fish insert with valid owner" ON fish;
+DROP POLICY IF EXISTS "Fish update with valid owner" ON fish;
+DROP POLICY IF EXISTS "Fish delete with valid owner" ON fish;
+
+-- SELECT Policy: Allow public read access to all fish
+-- Anyone can read any fish's data (public information)
+CREATE POLICY "Public read access for fish"
+ON fish
+FOR SELECT
+TO public
+USING (true);
+
+-- INSERT Policy: Allow insert if owner exists in players table
+-- Validates that the owner is a valid player before allowing fish creation
+-- This prevents orphaned fish records and ensures data integrity
+CREATE POLICY "Fish insert with valid owner"
+ON fish
+FOR INSERT
+TO public
+WITH CHECK (
+  -- Validate that owner exists in players table
+  -- owner refers to NEW.owner in WITH CHECK for INSERT policies
+  EXISTS (
+    SELECT 1 FROM players WHERE address = owner
+  )
+);
+
+-- UPDATE Policy: Allow update if owner exists in players table
+-- Validates that the owner (existing or new) is a valid player
+-- This ensures fish can only be updated if the owner relationship is valid
+CREATE POLICY "Fish update with valid owner"
+ON fish
+FOR UPDATE
+TO public
+USING (
+  -- Validate that current owner exists in players table
+  -- owner refers to OLD.owner in USING for UPDATE policies
+  EXISTS (
+    SELECT 1 FROM players WHERE address = owner
+  )
+)
+WITH CHECK (
+  -- Validate that new owner (if changed) exists in players table
+  -- owner refers to NEW.owner in WITH CHECK for UPDATE policies
+  EXISTS (
+    SELECT 1 FROM players WHERE address = owner
+  )
+);
+
+-- DELETE Policy: Allow delete if owner exists in players table
+-- Validates that the owner is a valid player before allowing deletion
+-- This ensures data integrity is maintained during deletions
+CREATE POLICY "Fish delete with valid owner"
+ON fish
+FOR DELETE
+TO public
+USING (
+  -- Validate that owner exists in players table
+  -- owner refers to OLD.owner in USING for DELETE policies
+  EXISTS (
+    SELECT 1 FROM players WHERE address = owner
+  )
+);
+
+-- Add comment documenting RLS policies
+COMMENT ON TABLE fish IS 'RLS enabled: Public read, owner validation for write operations. Backend uses service_role which bypasses RLS.';
+


### PR DESCRIPTION
## 🔗 Related Issue
Closes #70

---

## 📝 Description

This PR implements Row-Level Security (RLS) policies for the `fish` table to secure fish data and ensure proper ownership validation. The implementation adds comprehensive RLS policies that validate the relationship between fish and players, ensuring data integrity and preventing orphaned records.

The implementation adds RLS policies that:
- Allow public read access to all fish data (profile information)
- Restrict INSERT operations to validate that the `owner` exists in the `players` table
- Restrict UPDATE operations to validate that the `owner` (current and new) exists in the `players` table
- Restrict DELETE operations to validate that the `owner` exists in the `players` table

**Important Note:** The backend uses `service_role` which bypasses RLS, so these policies serve as a defense-in-depth layer for direct database access without `service_role`. The backend already validates ownership in business logic, and RLS provides an additional security layer.

---

## 🔄 Changes Made

- [x] Enable RLS on `fish` table (if not already enabled)
- [x] Create SELECT policy: Allow public read access to all fish
- [x] Create INSERT policy: Allow insert if `owner` exists in `players` table (validates FK relationship)
- [x] Create UPDATE policy: Allow update if `owner` exists in `players` table (validates both current and new owner)
- [x] Create DELETE policy: Allow delete if `owner` exists in `players` table
- [x] Create migration file: `20251226125338_enable_rls_policies_fish.sql`
- [x] Make policies idempotent using `DROP POLICY IF EXISTS`
- [x] Add documentation comments to the migration

---

## 📸 Screenshots (if applicable)
N/A - Database migration only

---

## 🗒️ Additional Notes

**RLS Policy Implementation Details:**

1. **SELECT Policy:** Public access to read any fish data (required for viewing fish information)
2. **INSERT Policy:** Validates that the `owner` exists in the `players` table using `EXISTS` subquery before allowing fish creation
3. **UPDATE Policy:** Validates that both the current owner (in `USING` clause) and new owner (in `WITH CHECK` clause) exist in the `players` table
4. **DELETE Policy:** Validates that the `owner` exists in the `players` table before allowing deletion

**Data Integrity:**
- Policies use `EXISTS` subqueries to efficiently validate the foreign key relationship
- Prevents creation of fish records with invalid owners
- Prevents updating fish to have invalid owners
- Ensures data consistency between `fish` and `players` tables

**Migration Safety:**
- All policies use `DROP POLICY IF EXISTS` for idempotency
- Migration has been tested and applied successfully to the remote database
- Backend operations continue to work normally as they use `service_role` which bypasses RLS
- Existing fish operations (feed, breed, starter pack minting) continue to function correctly

**Testing Considerations:**
- Migration applied successfully to remote database
- Existing fish operations verified to continue working (service_role bypass)
- Policies ready for testing with direct database access scenarios
- Starter pack minting flow should continue to work correctly