### PR TITLE
Row-Level Security (RLS) policies for the `sync_queue` table

### DIFF
--- a/supabase/migrations/20251226130123_enable_rls_policies_sync_queue.sql
+++ b/supabase/migrations/20251226130123_enable_rls_policies_sync_queue.sql
@@ -1,0 +1,64 @@
+-- Enable Row-Level Security (RLS) on sync_queue table
+-- This migration implements RLS policies for the sync_queue table to restrict access to backend only
+-- Note: Backend uses service_role which bypasses RLS, so these policies protect against accidental anon key usage
+-- This table is internal system data and must NOT be accessible via public or authenticated roles
+
+-- Enable RLS if not already enabled
+ALTER TABLE sync_queue ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist (for idempotency)
+DROP POLICY IF EXISTS "Deny all public access to sync_queue" ON sync_queue;
+DROP POLICY IF EXISTS "Deny all public insert to sync_queue" ON sync_queue;
+DROP POLICY IF EXISTS "Deny all public update to sync_queue" ON sync_queue;
+DROP POLICY IF EXISTS "Deny all public delete to sync_queue" ON sync_queue;
+DROP POLICY IF EXISTS "Deny all authenticated access to sync_queue" ON sync_queue;
+
+-- SELECT Policy: Deny all public access
+-- This policy explicitly denies SELECT operations for public role
+-- service_role bypasses RLS, so backend access continues to work
+CREATE POLICY "Deny all public access to sync_queue"
+ON sync_queue
+FOR SELECT
+TO public
+USING (false);
+
+-- INSERT Policy: Deny all public access
+-- This policy explicitly denies INSERT operations for public role
+-- service_role bypasses RLS, so backend access continues to work
+CREATE POLICY "Deny all public insert to sync_queue"
+ON sync_queue
+FOR INSERT
+TO public
+WITH CHECK (false);
+
+-- UPDATE Policy: Deny all public access
+-- This policy explicitly denies UPDATE operations for public role
+-- service_role bypasses RLS, so backend access continues to work
+CREATE POLICY "Deny all public update to sync_queue"
+ON sync_queue
+FOR UPDATE
+TO public
+USING (false)
+WITH CHECK (false);
+
+-- DELETE Policy: Deny all public access
+-- This policy explicitly denies DELETE operations for public role
+-- service_role bypasses RLS, so backend access continues to work
+CREATE POLICY "Deny all public delete to sync_queue"
+ON sync_queue
+FOR DELETE
+TO public
+USING (false);
+
+-- Also deny access for authenticated role (defense in depth)
+-- Even though we don't use Supabase Auth, this prevents future accidental access
+CREATE POLICY "Deny all authenticated access to sync_queue"
+ON sync_queue
+FOR ALL
+TO authenticated
+USING (false)
+WITH CHECK (false);
+
+-- Add comment documenting RLS policies
+COMMENT ON TABLE sync_queue IS 'RLS enabled: Backend-only access. All public and authenticated access denied. Backend uses service_role which bypasses RLS.';
+


### PR DESCRIPTION
## 🔗 Related Issue
Closes #73

---

## 📝 Description

This PR implements Row-Level Security (RLS) policies for the `sync_queue` table to completely restrict access to backend operations only. Unlike other tables in the system, `sync_queue` is an internal system table used for synchronizing on-chain and off-chain data, and must not be accessible to public or authenticated users.

The implementation adds comprehensive RLS policies that:
- Deny all SELECT operations for public and authenticated roles
- Deny all INSERT operations for public and authenticated roles
- Deny all UPDATE operations for public and authenticated roles
- Deny all DELETE operations for public and authenticated roles

**Important Note:** The backend uses `service_role` which bypasses RLS, so these policies protect against accidental use of `anon` key while allowing backend operations to continue working normally. This ensures that sensitive transaction synchronization data remains completely private.

---

## 🔄 Changes Made

- [x] Enable RLS on `sync_queue` table (if not already enabled)
- [x] Create SELECT policy: Deny all public access (using `USING (false)`)
- [x] Create INSERT policy: Deny all public access (using `WITH CHECK (false)`)
- [x] Create UPDATE policy: Deny all public access (using `USING (false)` and `WITH CHECK (false)`)
- [x] Create DELETE policy: Deny all public access (using `USING (false)`)
- [x] Create policy: Deny all authenticated access as defense-in-depth
- [x] Create migration file: `20251226130123_enable_rls_policies_sync_queue.sql`
- [x] Make policies idempotent using `DROP POLICY IF EXISTS`
- [x] Add documentation comments explaining backend-only access

---

## 📸 Screenshots (if applicable)
N/A - Database migration only

---

## 🗒️ Additional Notes

**RLS Policy Implementation Details:**

1. **All Public Policies:** Explicitly deny all operations (SELECT, INSERT, UPDATE, DELETE) for the `public` role using `USING (false)` and `WITH CHECK (false)`
2. **Authenticated Policy:** Denies all operations for the `authenticated` role as defense-in-depth, even though Supabase Auth is not currently used
3. **Service Role Bypass:** The backend uses `service_role` key which bypasses RLS, so all backend operations continue to work normally

**Security Model:**
- `sync_queue` contains sensitive transaction hash data and internal state management
- Policies ensure complete isolation from public access
- Protects against accidental use of `anon` key in code
- Prevents external clients from manipulating sync queue entries
- Maintains data integrity for critical synchronization operations

**Why Explicit Policies Instead of Default Deny:**
- Explicit policies document the security intent clearly
- Provides defense-in-depth protection
- Makes the security model obvious to reviewers and future maintainers
- Ensures consistent approach if RLS behavior changes in future PostgreSQL versions

**Migration Safety:**
- All policies use `DROP POLICY IF EXISTS` for idempotency
- Migration has been tested and applied successfully to the remote database
- Backend operations continue to work normally (service_role bypasses RLS)
- Sync queue operations in `SyncService` continue to function correctly
- No breaking changes to existing functionality

**Testing Considerations:**
- Migration applied successfully to remote database
- Backend sync queue operations verified to continue working (service_role bypass)
- All public and authenticated access explicitly denied
- Policies protect against accidental `anon` key usage
- This is different from other tables - it's backend-only, not player-owned

**Related Context:**
- This table tracks blockchain transaction synchronization (`tx_hash`, `entity_type`, `entity_id`, `status`)
- Used internally by backend for data consistency between on-chain and off-chain state
- Contains sensitive transaction data that must remain private